### PR TITLE
added dmenu-session script example

### DIFF
--- a/user-scripts/README
+++ b/user-scripts/README
@@ -1,0 +1,19 @@
+dmenu-session
+-------------
+
+This script creates nice dmenu at bottom with suggested actions for session.
+It works with dmenu application, so it should be installed. Code was taken from 
+https://bbs.archlinux.org/viewtopic.php?id=95984
+
+Copy to /usr/local/bin/dmenu-session. Change colors or prompt
+to your needs. Change mod to executable.
+
+    chmod +x dmenu-session
+
+Bind key to your newly created script in Qtile config.
+
+    <...>
+    Key([mod, 'control'], 'q', lazy.spawn('dmenu-session')),
+    <...>
+
+What's it. Now after Qtile reload you should get nice menu at bottom.

--- a/user-scripts/dmenu-session
+++ b/user-scripts/dmenu-session
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# a simple dmenu session script 
+# from https://bbs.archlinux.org/viewtopic.php?id=95984
+#
+###
+
+DMENU='dmenu -i -b -p >>> -nb #000 -nf #fff -sb #00BF32 -sf #fff'
+choice=$(echo -e "lock\nlogout\nshutdown\nreboot\nsuspend\nhibernate" | $DMENU)
+
+case "$choice" in
+  lock) gnome-screensaver-command --lock ;;
+  logout) gksu kill $(pgrep X) & ;;
+  shutdown) gksu "shutdown -h now" & ;;
+  reboot) gksu "shutdown -r now" & ;;
+  suspend) gksu pm-suspend && gnome-screensaver-command --lock ;;
+  hibernate) gksu pm-hibernate && gnome-screensaver-command --lock ;;
+esac


### PR DESCRIPTION
As was commented on https://github.com/qtile/qtile/pull/357, I moved script to qtile-example. In root README there was speach about user-scripts directory for all 3rd party scripts, so I moved here. In README file wrote about script
