### PR TITLE
Change group to screen

### DIFF
--- a/dwakar/config.py
+++ b/dwakar/config.py
@@ -67,8 +67,8 @@ keys = [
     Key([mod], "x", lazy.window.kill()),
 
     # move to the adjacent screen
-    Key([mod], "Left", lazy.group.prevgroup()),
-    Key([mod], "Right", lazy.group.nextgroup()),
+    Key([mod], "Left", lazy.screen.prevgroup()),
+    Key([mod], "Right", lazy.screen.nextgroup()),
     
     # interact with prompts
     Key([mod], "r", lazy.spawncmd()),


### PR DESCRIPTION
Because it doesn't change group and generates such errors:
```
2015-03-27 07:46:05,410 ERROR handle_KeyPress:854 KB command error nextgroup: No such command.
2015-03-27 07:46:06,058 ERROR handle_KeyPress:854 KB command error prevgroup: No such command.
2015-03-27 07:46:07,187 ERROR handle_KeyPress:854 KB command error nextgroup: No such command.
2015-03-27 07:46:08,042 ERROR handle_KeyPress:854 KB command error nextgroup: No such command.
```