### PR TITLE
Fix the import path.

### DIFF
--- a/aeronotix.py
+++ b/aeronotix.py
@@ -1,11 +1,9 @@
 from libqtile.command import lazy
 from libqtile import layout, bar, widget, hook
 try:
-    from libqtile.manager import Key, Group
+    from libqtile.manager import Key, Group, Click, Drag, Screen
 except ImportError:
-    from libqtile.config import Key, Group
-
-from libqtile.manager import Click, Drag, Screen
+    from libqtile.config import Key, Group, Click, Drag, Screen
 
 sup = "mod4"
 alt = "mod1"


### PR DESCRIPTION
I found a problem when the qtile reads the aeronotix.py. This patch fix the problem.
The Click, Drag and Screen modules are defined in the manager.py of the latest qtile.