### PR TITLE
Add SpyrosRoum config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "ani1001"]
 	path = ani1001
 	url = https://github.com/ani1001/dotfiles
+[submodule "SpyrosRoum"]
+	path = SpyrosRoum
+	url = https://github.com/SpyrosRoum/qtile-config.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # qtile-examples
-
 ## Table of Contents
 
 - [Configs](#configs)
@@ -40,6 +39,7 @@ tailhook.py     | unicode-based window sorting
 tin.py          | custom window shortcuts
 tych0           | qtile development, multiple screens
 zordsdavini     | various dmenu apps, screenshots, multiscreen, gmailwidget
+SpyrosRoum      | ability to toggle groups making them visible, like DWM
 
 ## Plugins
 


### PR DESCRIPTION
My config can emulate DWM tags to an extent by adding the ability to make more than one groups visible in the same screen.
