### PR TITLE
Refactor traverse script and improve edge cases

### DIFF
--- a/traverse.py
+++ b/traverse.py
@@ -9,85 +9,144 @@ Example usage:
     import traverse
 
     keys.extend([
-        Key([mod], 'k', lazy.function(traverse.up)),
-        Key([mod], 'j', lazy.function(traverse.down)),
-        Key([mod], 'h', lazy.function(traverse.left)),
-        Key([mod], 'l', lazy.function(traverse.right)),
+        Key([mod], "k", lazy.function(traverse.up)),
+        Key([mod], "j", lazy.function(traverse.down)),
+        Key([mod], "h", lazy.function(traverse.left)),
+        Key([mod], "l", lazy.function(traverse.right)),
     ])
 
-Qtile versions known to work: 0.16 - 0.18
+Qtile versions known to work: 0.22.1
 """
 
+from dataclasses import dataclass
+from typing import Optional
+
 from libqtile.config import Screen
+from libqtile.backend.base import Window
 
 
 def up(qtile):
-    _focus_window(qtile, -1, 'y')
+    """Focus next window or empty screen up"""
+    _focus_window(qtile, Transform(exchange=True, flip=True))
 
 
 def down(qtile):
-    _focus_window(qtile, 1, 'y')
+    """Focus next window or empty screen down"""
+    _focus_window(qtile, Transform(exchange=True, flip=False))
 
 
 def left(qtile):
-    _focus_window(qtile, -1, 'x')
+    """Focus next window or empty screen to the left"""
+    _focus_window(qtile, Transform(exchange=False, flip=True))
 
 
 def right(qtile):
-    _focus_window(qtile, 1, 'x')
+    """Focus next window or empty screen to the right"""
+    _focus_window(qtile, Transform(exchange=False, flip=False))
 
 
-def _focus_window(qtile, dir, axis):
-    win = None
-    win_wide = None
-    dist = 10000
-    dist_wide = 10000
-    cur = qtile.current_window
-    if not cur:
-        cur = qtile.current_screen
+def focusable(qtile):
+    """Get all windows and screens that should be considered for navigation"""
+    yield from (
+        window
+        for screen in qtile.screens
+        for window in screen.group.windows
+        if window is not qtile.current_window
+    )
+    yield from (
+        screen
+        for screen in qtile.screens
+        if not screen.group.windows # only consider empty screens
+        and screen is not qtile.current_screen
+    )
 
-    if axis == 'x':
-        dim = 'width'
-        band_axis = 'y'
-        band_dim = 'height'
-        cur_pos = cur.x
-        band_min = cur.y
-        band_max = cur.y + cur.height
-    else:
-        dim = 'height'
-        band_axis = 'x'
-        band_dim = 'width'
-        band_min = cur.x
-        cur_pos = cur.y
-        band_max = cur.x + cur.width
 
-    cur_pos += getattr(cur, dim) / 2
+@dataclass
+class Point:
+    """Point in virtual coordinates"""
+    main: int
+    cross: int
 
-    windows = [w for g in qtile.groups if g.screen for w in g.windows]
-    windows.extend([s for s in qtile.screens if not s.group.windows])
+@dataclass
+class Rectangle:
+    """Store the dimensions of a rectangle in virtual coordinates"""
+    obj: Window | Screen
+    main: int
+    cross: int
+    length: int
+    breadth: int
 
-    if cur in windows:
-        windows.remove(cur)
+    @property
+    def center(self) -> Point:
+        """Return the center point of the rectangle"""
+        return Point(
+            self.main + self.length / 2,
+            self.cross + self.breadth / 2,
+        )
 
-    for w in windows:
-        if isinstance(w, Screen) or not w.minimized:
-            pos = getattr(w, axis) + getattr(w, dim) / 2
-            gap = dir * (pos - cur_pos)
-            if gap > 5:
-                band_pos = getattr(w, band_axis) + getattr(w, band_dim) / 2
-                if band_min < band_pos < band_max:
-                    if gap < dist:
-                        dist = gap
-                        win = w
-                else:
-                    if gap < dist_wide:
-                        dist_wide = gap
-                        win_wide = w
+    @property
+    def is_visible(self) -> bool:
+        """Determine whether the rectangle is currently visible on the screen"""
+        return isinstance(self.obj, Screen) or self.obj.cmd_is_visible()
 
-    if not win:
-        win = win_wide
-    if win:
-        qtile.focus_screen(win.group.screen.index)
-        win.group.focus(win, True)
-        if not isinstance(win, Screen):
-            win.focus(False)
+
+@dataclass
+class Transform:
+    """Define how to extract coordinates form Window and Screen
+
+    exchange - exchange x and y
+    flip - mirror the main axis direction
+    """
+
+    exchange: bool
+    flip: bool
+
+    def __call__(self, obj: Window | Screen) -> Rectangle:
+        tmp_x = -obj.x - obj.width if self.flip else obj.x
+        tmp_y = -obj.y - obj.height if self.flip else obj.y
+        return Rectangle(
+            obj,
+            tmp_y if self.exchange else tmp_x,
+            tmp_x if self.exchange else tmp_y,
+            obj.height if self.exchange else obj.width,
+            obj.width if self.exchange else obj.height,
+        )
+
+def _focus_window(qtile, transform) -> Optional[Window | Screen]:
+    focused = transform(qtile.current_window or qtile.current_screen)
+    band_min = focused.cross
+    band_max = focused.cross + focused.breadth
+
+    # Filter to only consider visible objects in the correct direction
+    candidates = filter(
+        lambda candidate: candidate.center.main > focused.center.main + 5 and candidate.is_visible,
+        map(transform, focusable(qtile))
+    )
+
+    # Then take closest in direction of the main axis, but prefer those on the
+    # same level as the current window.
+    closest = sorted(candidates, key=lambda candidate:
+         (
+            0 if band_min <= candidate.cross <= band_max
+              or band_min <= candidate.cross + candidate.breadth <= band_max
+            else 1,
+            candidate.center.main,
+            abs(focused.center.cross - candidate.center.cross),
+        )
+    )
+
+    if not closest:
+        # Could not find anything to focus. Maybe this is the edge of the known space :-D
+        return None
+
+    target = closest[0].obj
+
+    qtile.focus_screen(target.group.screen.index)
+    qtile.core.warp_pointer(target.x + target.width / 2, target.y + target.height / 2)
+
+    if isinstance(target, Window):
+        target.group.focus(target, True)
+        target.focus(False)
+        target.cmd_bring_to_front()
+
+    return target


### PR DESCRIPTION
I had some edge cases where the traverse script did not work well,
so I took some time and refactored it and added:

- warp pointer to focused window
- focused window is brought to the front
- hidden windows are ignored
- candidates where the cross direction span overlaps with the current window are considered "in band"
  (previously only the center of the candidate was used)

The machinery might be a slight overkill, but it seems much more readable to me now :-)