### PR TITLE
Added spawn default app module

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ floating_window_snapping| Floating window borders snap to other window/screen bo
 [qtile-plasma](https://github.com/numirias/qtile-plasma) | An tree-based layout, very similar to i3
 toggle_debug            | A command to toggle debug logging with notification
 tidygroups              | Function for moving windows to the leftmost groups (like dwm's `reorganizetags`)
+spawn_default_app       | A function for setting, and then spawning a default app for each group based on a single keybind.
 
 ## Other links
 

--- a/spawn_default_app.py
+++ b/spawn_default_app.py
@@ -1,0 +1,56 @@
+"""
+Spawn the default app set for each group.
+
+For example, if you set up your first group with a default
+app of "firefox", your second group with a default app of
+"vscode", and didn't set a default app for the remainder of 
+your groups, then when you switch to the first group and call
+this function, it will spawn firefox. When you switch to the
+second group and call this function, it will spawn vscode.
+When you switch to any other group and call this function, it
+will spawn the application specified by unset_default_app.
+
+Setup:
+
+    To start, define a list of default apps the same length
+    as your list of groups. If you don't want to set a default
+    app for a group, set the value to None. You can then call
+    this function from your keybinds by passing in your list
+    of groups and default apps to spawn the default app for the
+    current group.
+
+Usage:
+
+    from spawn_default_app import spawn_default_app
+
+    run_launcher = "<your_run_launcher_here>"
+
+    default_apps = ["firefox", "code", "nemo", None, None, "firefox", None, "discord", "pavucontrol", "terminator -e bpytop",]
+
+    keys.extend([
+        Key([mod], "t", lazy.function(spawn_default_app, groups, default_apps, unset_default_app=run_launcher), desc="Spawn the default app for the current group")
+    ])
+"""
+
+from libqtile.lazy import lazy
+
+def spawn_default_app(qtile, groups: list, default_apps: list[str], use_run_as_unset_default: bool = False, unset_default_app: str = None) -> None:
+    def get_index(current_group_name: str) -> None:
+        if groups:
+            for i in range(len(groups)):
+                if groups[i].name == current_group_name:
+                    return i
+            return None
+        else:
+            return None
+
+    group_index = get_index(qtile.current_group.name) if qtile.current_group is not None else None
+    if qtile.current_group is not None and group_index is not None and default_apps is not None and default_apps[group_index] is not None:
+        app = default_apps[group_index]
+        qtile.cmd_spawn(app)
+    else:
+        if use_run_as_unset_default or unset_default_app is None:
+            lazy.spawncmd()
+        else:
+            qtile.cmd_spawn(unset_default_app)
+


### PR DESCRIPTION
This adds a module that includes a function to store and then later spawn default applications for each group. A user can set a single key bind (I use mod + t) that when pressed will spawn the default application for the current group.

This is the initial implementation of this solution. It isn't quite clean enough for my liking, so I also wrote a more integrated version over on the main qtile repo [here](https://github.com/qtile/qtile/pull/4253). My intention is to present both solutions and let the maintainers decide which solution better fits the project.